### PR TITLE
chore: release v3.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-teamtalk-macros = { version = "0.1.0", path = "crates/teamtalk-macros" }
+teamtalk-macros = { version = "3.1.0", path = "crates/teamtalk-macros" }
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/crates/teamtalk-macros/Cargo.toml
+++ b/crates/teamtalk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teamtalk-macros"
-version = "0.1.0"
+version = "3.1.0"
 edition = "2024"
 authors = ["BlindMaster24"]
 description = "Proc macros for TeamTalk bot routing"


### PR DESCRIPTION



## 🤖 New release

* `teamtalk-macros`: 0.1.0 -> 3.1.0
* `teamtalk`: 3.0.0 -> 3.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `teamtalk-macros`

<blockquote>

## [3.1.0](https://github.com/BlindMaster24/TeamTalkRust/compare/v3.0.0...v3.1.0) - 2026-02-21

### Added
- *(bot)* add optional bot macros and async wait parity
- *(bot)* add dialog flow and wait helpers in context
- *(bot)* add BotApp facade for sync and async runtimes
- *(bot)* add typed args, reply helpers, and unknown command policy

### Changed
- *(client)* remove remaining lock unwrap panics
- *(client)* recover from poisoned mutexes
- *(client)* avoid lock-held callback dispatch

### Fixed
- *(async)* harden shutdown wake and DLL load guard

### Dependencies
- *(deps)* refresh workspace dependency versions
</blockquote>

## `teamtalk`

<blockquote>

## [3.1.0](https://github.com/BlindMaster24/TeamTalkRust/compare/v3.0.0...v3.1.0) - 2026-02-21

### Added
- *(bot)* add optional bot macros and async wait parity
- *(bot)* add dialog flow and wait helpers in context
- *(bot)* add BotApp facade for sync and async runtimes
- *(bot)* add typed args, reply helpers, and unknown command policy

### Changed
- *(client)* remove remaining lock unwrap panics
- *(client)* recover from poisoned mutexes
- *(client)* avoid lock-held callback dispatch

### Fixed
- *(async)* harden shutdown wake and DLL load guard

### Dependencies
- *(deps)* refresh workspace dependency versions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).